### PR TITLE
fix: CocInstall should work

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,7 @@
     "glob": "^7.1.2",
     "typescript": "^2.6.1",
     "lodash": "4.17.4",
-    "rxjs": "6.3.3"
-  },
-  "devDependencies": {
+    "rxjs": "6.3.3",
     "@types/glob": "^5.0.30",
     "@types/lodash": "4.14.117",
     "@types/mocha": "^2.2.42",


### PR DESCRIPTION
Thanks for this, it saved me a lot of trouble at work where people insisted on using this vscode plugin for formatting, and I insist on using neovim :D

:CocInstall wouldn't work since devDependencies weren't installed so I just made everything a dependency instead, which solved it... Might not be the optimal solution, but it worked for me

Not sure if you still use this, but figured it could be useful for someone else to be able to install this without bughunting